### PR TITLE
Fix deprecated syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ mod tests {
 
         let mut val = MutGuard::new(LessThan20(0));
 
-        let v = val.guard();
+        let _v = val.guard();
         panic!("other panic");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ impl<'a, T: Guard> Drop for MutGuardBorrow<'a, T> {
 /// `Guard` implementation returned by `MutGuard::wrap()`
 pub struct MutGuardWrapper<'a, T> {
     inner: T,
-    f: Box<'a + FnMut(&mut T)>,
+    f: Box<dyn 'a + FnMut(&mut T)>,
 }
 
 impl<'a, T: 'a> MutGuardWrapper<'a, T> {


### PR DESCRIPTION
Use of trait objects without `dyn` is now deprecated
